### PR TITLE
opcode 3Ah é "ld a, (**)" e o 32h é "ld (**), a"

### DIFF
--- a/rot1/rotina1-roadsec.asm
+++ b/rot1/rotina1-roadsec.asm
@@ -48,7 +48,7 @@ DAF0: CD 4D 00      call READ_VRAM
 DAF3: 09            add hl, bc
 DAF4: F1            pop af
 DAF5: 3D            dec a
-DAF9: 3A 40 F2      ld (CHAR), a
+DAF9: 3A 40 F2      ld a, (CHAR)
 DAFC: CD 4D 00      call WRITE_VRAM
 DAFF: 13            inc de
 DB00: D5            push de

--- a/rot1/rotina1.asm
+++ b/rot1/rotina1.asm
@@ -33,7 +33,7 @@ DAF3: 09            add hl, bc
 DAF4: F1            pop af
 DAF5: 3D            dec a
 DAF6: c2 F9 DA      jp nz, 0xDAF9
-DAF9: 3A 40 F2      ld (0xF240), a
+DAF9: 3A 40 F2      ld a, (0xF240)
 DAFC: CD 4D 00      call 0x004D
 DAFF: 13            inc de
 DB00: D5            push de


### PR DESCRIPTION
O opcode 3Ah sempre tem a forma `ld a, (**)`, então não é possível que a desmontagem  dê `ld (**), a`. Para isso acontecer, o opcode teria que ser outro: 32h.